### PR TITLE
fix: Handle proxied image urls in seed-from-api

### DIFF
--- a/src/lib/database/seed-from-api.ts
+++ b/src/lib/database/seed-from-api.ts
@@ -98,11 +98,11 @@ export const seedDatabaseFromApi = async (
 }
 
 const getImageIdFromImageUrl = (url: string): string => {
-  const searchParams = new URL(url).searchParams
-  const image_id = searchParams.get("image_id")
+  const search_params = new URL(url).searchParams
+  const image_id = search_params.get("image_id")
   if (image_id) return image_id
 
-  const proxied_url = searchParams.get("url")
+  const proxied_url = search_params.get("url")
   if (!proxied_url) throw new Error(`No image_id in "${url}"`)
   return getImageIdFromImageUrl(proxied_url)
 }

--- a/src/lib/database/seed-from-api.ts
+++ b/src/lib/database/seed-from-api.ts
@@ -98,11 +98,11 @@ export const seedDatabaseFromApi = async (
 }
 
 const getImageIdFromImageUrl = (url: string): string => {
-  const image_url = new URL(url)
-  const image_id = image_url.searchParams.get("image_id")
-  if (image_id == null) {
-    throw new Error(`No image_id in ${url}`)
-  }
+  const searchParams = new URL(url).searchParams
+  const image_id = searchParams.get("image_id")
+  if (image_id) return image_id
 
-  return image_id
+  const proxied_url = searchParams.get("url")
+  if (!proxied_url) throw new Error(`No image_id in "${url}"`)
+  return getImageIdFromImageUrl(proxied_url)
 }

--- a/src/lib/database/seed-from-api.ts
+++ b/src/lib/database/seed-from-api.ts
@@ -98,11 +98,11 @@ export const seedDatabaseFromApi = async (
 }
 
 const getImageIdFromImageUrl = (url: string): string => {
-  const search_params = new URL(url).searchParams
-  const image_id = search_params.get("image_id")
-  if (image_id) return image_id
+  const searchParams = new URL(url).searchParams
+  const imageId = searchParams.get("image_id")
+  if (imageId) return imageId
 
-  const proxied_url = search_params.get("url")
-  if (!proxied_url) throw new Error(`No image_id in "${url}"`)
-  return getImageIdFromImageUrl(proxied_url)
+  const proxiedUrl = searchParams.get("url")
+  if (!proxiedUrl) throw new Error(`No image_id in "${url}"`)
+  return getImageIdFromImageUrl(proxiedUrl)
 }

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -92,6 +92,19 @@ test("seed database from api", async (t) => {
     await seedDatabaseFromApi(db, client)
   })
 
+  const client_with_proxied_images = axios.create({
+    baseURL: serverURL,
+    headers: {
+      "x-vercel-protection-bypass": db.vercel_protection_bypass_secret,
+      "x-forwarded-seam-base-url":
+        "https://example.com/devicedb?url=https://example.com/devicedb",
+    },
+  })
+
+  await t.notThrowsAsync(async () => {
+    await seedDatabaseFromApi(db, client_with_proxied_images)
+  })
+
   t.deepEqual(db.manufacturers[0], { ...manufacturer, device_model_count: 1 })
   t.deepEqual(db.device_models[0], device_model)
 })


### PR DESCRIPTION
https://github.com/seamapi/react/issues/646

Images can be returned through Next's image processor, this PR allows `getImageIdFromImageUrl` to find `image_id` even when the image url is proxied by Next